### PR TITLE
First pass at set-theoretical simplify.

### DIFF
--- a/sims/simplify-alg.py
+++ b/sims/simplify-alg.py
@@ -1,0 +1,85 @@
+"""
+Set-theoretic algorithm implementation of Algorithm S.
+"""
+import collections
+import msprime
+import numpy as np
+
+def simplify(S, Ni, Ei, L):
+    No = msprime.NodeTable()
+    Eo = msprime.EdgeTable()
+    left = Ei.left.astype(int)
+    right = Ei.right.astype(int)
+    child = Ei.child
+    parent = Ei.parent
+    time = Ni.time
+    A = collections.defaultdict(set)
+    M = {}
+    for input_id in S:
+        # TODO update node table to return ID of new row.
+        output_id = len(No)
+        No.add_row(time=time[input_id])
+        M[input_id] = output_id
+        # TODO We probably need to make this a set of tuples, otherwise we lose the
+        # ability to track where individual bits have come from.
+        A[output_id] = set(range(L - 1))
+    for k, v in A.items():
+        print(k, "->", v)
+
+    # This isn't quite right as we've lost the ability to map nodes. Seems like
+    # it's OK otherwise.
+
+    for input_parent in range(len(Ni)):
+        index = parent == input_parent
+        print("parent = ", input_parent)
+        S = []
+        for l, r, c in zip(left[index], right[index], child[index]):
+            # Remove ancestry is now trivial; directly expressed as set operations.
+            x = set(range(l, r))
+            S.append(A[c] & x)
+            A[c] -= x
+        if len(S) > 0:
+            print("S = ", S)
+            A[input_parent] = S[0].union(*S[1:])
+            for k, v in A.items():
+                if len(v) > 0:
+                    print(k, "->", v)
+            inter = S[0].intersection(*S[1:])
+            if len(inter) > 0:
+                # Allocate a new node
+                output_parent = len(No)
+                No.add_row(time=time[input_parent])
+                M[input_parent] = output_parent
+
+                # Figure out which intervals they are children over.
+                for l, r, c in zip(left[index], right[index], child[index]):
+                    x = set(range(l, r))
+                    child_inter = x & inter
+                    if len(child_inter) > 0:
+                        # And we record the outptu edge
+                        print("EDGE {} {} over {}".format(c, input_parent, child_inter))
+
+
+
+
+
+
+
+if __name__ == "__main__":
+    # ts = msprime.simulate(10, recombination_rate=2, random_seed=1)
+    # ts.dump("example.ts")
+    # ts = msprime.simulate(10, recombination_rate=2, random_seed=1)
+    # ts.dump("example.ts")
+    ts = msprime.load("example.ts")
+    nodes= ts.tables.nodes
+    edges = ts.tables.edges
+    # convert left and right to breakpoints
+    breakpoints = np.unique(np.hstack([edges.left, edges.right]))
+    breakpoint_map = dict(zip(breakpoints, range(breakpoints.shape[0])))
+    # Build a new edge table
+    edges = msprime.EdgeTable()
+    for e in ts.edges():
+        edges.add_row(
+            breakpoint_map[e.left], breakpoint_map[e.right], e.parent, e.child)
+
+    ts_new = simplify([0, 1, 2], nodes, edges, len(breakpoint_map))

--- a/sims/simplify-alg.py
+++ b/sims/simplify-alg.py
@@ -1,9 +1,49 @@
 """
 Set-theoretic algorithm implementation of Algorithm S.
 """
-import collections
-import msprime
 import numpy as np
+
+import msprime
+import intervaltree
+
+def simplify(S, Ni, Ei, L):
+    No = msprime.NodeTable()
+    Eo = msprime.EdgeTable()
+    left = Ei.left
+    right = Ei.right
+    child = Ei.child
+    parent = Ei.parent
+    time = Ni.time
+    # TODO Should be an interval tree for each ID.
+    A = {}
+    for input_id in S:
+        # TODO update node table to return ID of new row.
+        output_id = len(No)
+        No.add_row(time=time[input_id], flags=1)
+        A[output_id] = intervaltree.IntervalTree([
+            intervaltree.Interval(0, L, input_id)])
+    print(A)
+
+    for input_parent in range(len(Ni)):
+        index = parent == input_parent
+        output_id = -1
+        S = []
+        for l, r, c in zip(left[index], right[index], child[index]):
+            # TODO Snip out this part of the interval tree for c, and save it in a
+            # list of intervals.
+            if c in A:
+                P = A[c][l: r]
+                print(P)
+
+            # # For each locus, transfer any genetic material to the parent.
+            # P = np.zeros(L, dtype=int) - 1
+            # P[l: r] = A[c, l: r]
+            # A[c, l: r] = -1
+            # # Store the transferred genetic material for all parents in the
+            # # list S so that we can find any coalescences afterwards.
+            # S.append(P)
+
+
 
 
 class Edge(object):
@@ -18,7 +58,7 @@ class Edge(object):
 
 
 
-def simplify(S, Ni, Ei, L):
+def simplify_loci(S, Ni, Ei, L):
     No = msprime.NodeTable()
     Eo = msprime.EdgeTable()
     left = Ei.left.astype(int)
@@ -125,17 +165,17 @@ if __name__ == "__main__":
     nodes= ts.tables.nodes
     edges = ts.tables.edges
 
-    # convert left and right to breakpoints
-    breakpoints = np.unique(np.hstack([edges.left, edges.right]))
-    breakpoint_map = dict(zip(breakpoints, range(breakpoints.shape[0])))
-    # Build a new edge table
-    edges = msprime.EdgeTable()
-    for e in ts.edges():
-        edges.add_row(
-            breakpoint_map[e.left], breakpoint_map[e.right], e.parent, e.child)
+#     # convert left and right to breakpoints
+#     breakpoints = np.unique(np.hstack([edges.left, edges.right]))
+#     breakpoint_map = dict(zip(breakpoints, range(breakpoints.shape[0])))
+#     # Build a new edge table
+#     edges = msprime.EdgeTable()
+#     for e in ts.edges():
+#         edges.add_row(
+#             breakpoint_map[e.left], breakpoint_map[e.right], e.parent, e.child)
 
     sample = [0, 1, 2]
-    ts1 = simplify(sample, nodes, edges, len(breakpoint_map) - 1)
+    ts1 = simplify(sample, nodes, edges, ts.sequence_length)
 
     print(ts1.tables)
 

--- a/sims/simplify-alg.py
+++ b/sims/simplify-alg.py
@@ -6,6 +6,7 @@ import numpy as np
 import msprime
 import intervaltree
 
+
 def simplify(S, Ni, Ei, L):
     No = msprime.NodeTable()
     Eo = msprime.EdgeTable()
@@ -15,34 +16,63 @@ def simplify(S, Ni, Ei, L):
     parent = Ei.parent
     time = Ni.time
     # TODO Should be an interval tree for each ID.
-    A = {}
+    A = [intervaltree.IntervalTree() for _ in range(len(Ni))]
     for input_id in S:
         # TODO update node table to return ID of new row.
         output_id = len(No)
         No.add_row(time=time[input_id], flags=1)
-        A[output_id] = intervaltree.IntervalTree([
-            intervaltree.Interval(0, L, input_id)])
-    print(A)
+        A[output_id] = intervaltree.IntervalTree([intervaltree.Interval(0, L, input_id)])
 
+    E = []
     for input_parent in range(len(Ni)):
         index = parent == input_parent
-        output_id = -1
-        S = []
+        new_output_id = -1
+        P = intervaltree.IntervalTree()
         for l, r, c in zip(left[index], right[index], child[index]):
-            # TODO Snip out this part of the interval tree for c, and save it in a
-            # list of intervals.
-            if c in A:
-                P = A[c][l: r]
-                print(P)
+            # We have to slice the intervals to make sure we only return the bits
+            # we're interested in.
+            A[c].slice(l)
+            A[c].slice(r)
+            # Note there's no need to actually remove the ancestral material. We just
+            # leave it in there because it can't affect anything later.
+            P = P.union(A[c][l: r])
+        P.split_overlaps()
+        for l, r, output_id in  P:
+            # We look at each distinct segment in turn. If there are coalescences, there
+            # will be segments that overlap each other which we detect by the effects
+            # on A[input_parent]
+            A[input_parent].slice(l)
+            A[input_parent].slice(r)
+            if len(A[input_parent][l: r]) == 0:
+                A[input_parent][l: r] = output_id
+            else:
+                if new_output_id == -1:
+                    new_output_id = len(No)
+                    No.add_row(time=time[input_parent], flags=0)
+                child_output_id = list(A[input_parent][l:r])[0].data
+                if child_output_id != new_output_id:
+                    E.append(Edge(l, r, new_output_id, child_output_id))
+                E.append(Edge(l, r, new_output_id, output_id))
+                A[input_parent].remove_overlap(l, r)
+                A[input_parent][l: r] = new_output_id
 
-            # # For each locus, transfer any genetic material to the parent.
-            # P = np.zeros(L, dtype=int) - 1
-            # P[l: r] = A[c, l: r]
-            # A[c, l: r] = -1
-            # # Store the transferred genetic material for all parents in the
-            # # list S so that we can find any coalescences afterwards.
-            # S.append(P)
+    # Sort the output locus-wise edges and compact them as much as possible into
+    # the output table. We can probably skip this for the algorithm listing as
+    # it's pretty mundane.
+    E.sort(key=lambda e: (e.parent, e.child, e.right, e.left))
+    start = 0
+    for j in range(1, len(E)):
+        condition = (
+            E[j - 1].right != E[j].left or
+            E[j - 1].parent != E[j].parent or
+            E[j - 1].child != E[j].child)
+        if condition:
+            Eo.add_row(E[start].left, E[j - 1].right, E[j - 1].parent, E[j - 1].child)
+            start = j
+    j = len(E)
+    Eo.add_row(E[start].left, E[j - 1].right, E[j - 1].parent, E[j - 1].child)
 
+    return msprime.load_tables(nodes=No, edges=Eo)
 
 
 
@@ -81,10 +111,9 @@ def simplify_loci(S, Ni, Ei, L):
         output_id = -1
         S = []
         for l, r, c in zip(left[index], right[index], child[index]):
-            # For each locus, transfer any genetic material to the parent.
+            # For each locus, pull out any genetic material and transfer to the parent.
             P = np.zeros(L, dtype=int) - 1
             P[l: r] = A[c, l: r]
-            A[c, l: r] = -1
             # Store the transferred genetic material for all parents in the
             # list S so that we can find any coalescences afterwards.
             S.append(P)
@@ -127,24 +156,26 @@ def simplify_loci(S, Ni, Ei, L):
 
 def verify():
     for n in [10, 100, 1000]:
-        ts = msprime.simulate(n, recombination_rate=5, random_seed=1)
+        ts = msprime.simulate(n, recombination_rate=1, random_seed=1)
         nodes= ts.tables.nodes
         edges = ts.tables.edges
         print("simulated for ", n)
 
-        # convert left and right to breakpoints
-        breakpoints = np.unique(np.hstack([edges.left, edges.right]))
-        breakpoint_map = dict(zip(breakpoints, range(breakpoints.shape[0])))
-        # Build a new edge table
-        edges = msprime.EdgeTable()
-        for e in ts.edges():
-            edges.add_row(
-                breakpoint_map[e.left], breakpoint_map[e.right], e.parent, e.child)
+        # # convert left and right to breakpoints
+        # breakpoints = np.unique(np.hstack([edges.left, edges.right]))
+        # breakpoint_map = dict(zip(breakpoints, range(breakpoints.shape[0])))
+        # # Build a new edge table
+        # edges = msprime.EdgeTable()
+        # for e in ts.edges():
+        #     edges.add_row(
+        #         breakpoint_map[e.left], breakpoint_map[e.right], e.parent, e.child)
 
         for N in range(2, 10):
             sample = list(range(N))
 
-            ts1 = simplify(sample, nodes, edges, len(breakpoint_map) - 1)
+            # ts1 = simplify_loci(sample, nodes, edges, len(breakpoint_map) - 1)
+            ts1 = simplify(sample, nodes, edges, ts.sequence_length)
+
             ts2 = ts.simplify(sample)
 
             n1 = ts1.tables.nodes
@@ -153,29 +184,32 @@ def verify():
             assert np.array_equal(n1.flags, n2.flags)
             e1 = ts1.tables.edges
             e2 = ts2.tables.edges
-            assert np.array_equal(breakpoints[e1.left.astype(int)], e2.left)
-            assert np.array_equal(breakpoints[e1.right.astype(int)], e2.right)
+            assert np.array_equal(e1.left, e2.left)
+            assert np.array_equal(e1.right, e2.right)
+            # assert np.array_equal(breakpoints[e1.left.astype(int)], e2.left)
+            # assert np.array_equal(breakpoints[e1.right.astype(int)], e2.right)
             assert np.array_equal(e1.parent, e1.parent)
             assert np.array_equal(e1.child, e1.child)
 
 if __name__ == "__main__":
-    # verify()
+    verify()
 
     ts = msprime.simulate(10, recombination_rate=2, random_seed=1)
     nodes= ts.tables.nodes
     edges = ts.tables.edges
 
-#     # convert left and right to breakpoints
-#     breakpoints = np.unique(np.hstack([edges.left, edges.right]))
-#     breakpoint_map = dict(zip(breakpoints, range(breakpoints.shape[0])))
-#     # Build a new edge table
-#     edges = msprime.EdgeTable()
-#     for e in ts.edges():
-#         edges.add_row(
-#             breakpoint_map[e.left], breakpoint_map[e.right], e.parent, e.child)
+    # convert left and right to breakpoints
+    # breakpoints = np.unique(np.hstack([edges.left, edges.right]))
+    # breakpoint_map = dict(zip(breakpoints, range(breakpoints.shape[0])))
+    # Build a new edge table
+    # edges = msprime.EdgeTable()
+    # for e in ts.edges():
+    #     edges.add_row(
+    #         breakpoint_map[e.left], breakpoint_map[e.right], e.parent, e.child)
 
     sample = [0, 1, 2]
     ts1 = simplify(sample, nodes, edges, ts.sequence_length)
+    # ts1 = simplify_loci(sample, nodes, edges, len(breakpoint_map) - 1)
 
     print(ts1.tables)
 


### PR DESCRIPTION
Here's some initial doodling for a set-theory version of simplify @petrelharp. The idea is that we can greatly simplify things if we look at the genetic intervals literally as sets (say we limit to a discrete genome). Most of the complexity of our algorithm comes from dealing with linked lists of segments.

The basic ideas are in here I think, but it's not fully there yet. I think what needs to be done is to make the elements of A dictionaries rather than sets, and it'll follow fairly easily from there. I'll make another pass on Monday and try to finish it, but I thought I'd share this much in case you'd like to take a look.