### PR TITLE
delete import of intervaltree, as it is not used.  

### DIFF
--- a/sims/simplify-alg.py
+++ b/sims/simplify-alg.py
@@ -10,7 +10,6 @@ import numpy as np
 import heapq
 
 import msprime
-import intervaltree
 
 
 class Segment(object):


### PR DESCRIPTION
This will likely cause import errors, so I removed it, as it is not used.