### PR TITLE
Fixed parathesis in grant ACK.

### DIFF
--- a/forwards_paper.tex
+++ b/forwards_paper.tex
@@ -1171,7 +1171,7 @@ and the Linux \texttt{time} command to record run time and peak memory usage of 
 
 %%%%%%%%%%%%%%%%%%%%%%
 \section*{Acknowledgements}
-Thanks to Jared Galloway, Brad Shaffer, and Evan McCartney--Melstad for useful discussions.
+Thanks to Gil McVean, Jared Galloway, Brad Shaffer, and Evan McCartney--Melstad for useful discussions.
 Work on this project was supported by funding from
 the Sloan Foundation and the NSF (under DBI-1262645) to PR;
 the Wellcome Trust (grant 100956/Z/13/Z) to Gil McVean;

--- a/forwards_paper.tex
+++ b/forwards_paper.tex
@@ -1174,7 +1174,7 @@ and the Linux \texttt{time} command to record run time and peak memory usage of 
 Thanks to Jared Galloway, Brad Shaffer, and Evan McCartney--Melstad for useful discussions.
 Work on this project was supported by funding from
 the Sloan Foundation and the NSF (under DBI-1262645) to PR;
-the Wellcome Trust (grant 100956/Z/13/Z to Gil McVean);
+the Wellcome Trust (grant 100956/Z/13/Z) to Gil McVean;
 the NIH (R01GM115564) to KRT.
 
 \bibliography{references}


### PR DESCRIPTION
Tiny tweak to the grant ACK. Doesn't matter for preprint, just correcting for submission purposes.