### PR TITLE
Fix link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,4 +2,4 @@ This contains miscellaneous material that goes along with
 [Efficient pedigree recording for fast population genetics simulation](https://www.biorxiv.org/content/early/2018/01/26/248500),
 by Jerome Kelleher, Kevin Thornton, Jaime Ashander, and Peter Ralph.
 
-- slides for [a talk](https://petrelharp.github.io/fprime_ms/broad_12_mar_2018.slides.html) on 12 March 2018
+- slides for [a talk](https://petrelharp.github.io/ftprime_ms/broad_12_mar_2018.slides.html) on 12 March 2018


### PR DESCRIPTION
fix typo in link

looking good! seeing commit history I guess symlink doesn't work and html must physically be in `docs/`. wild